### PR TITLE
problem that HTML special chars turned to character entities

### DIFF
--- a/emblem.js
+++ b/emblem.js
@@ -1,7 +1,7 @@
 var Emblem = {
   init: function(el, str) {
     var element = document.querySelector(el);
-    var text = str ? str : element.innerHTML;
+    var text = str ? str : element.innerText;
     element.innerHTML = '';
     for (var i = 0; i < text.length; i++) {
       var letter = text[i];


### PR DESCRIPTION
Trying to generate circular text which includes '<', I failed. So I wish the plugin makes it. I apologize for my poor English and my first github PR.